### PR TITLE
dropdown style for Win

### DIFF
--- a/portal/src/styles/globals.css
+++ b/portal/src/styles/globals.css
@@ -147,3 +147,8 @@ blockquote {
 blockquote p {
   display: inline;
 }
+
+option {
+  color: white;
+  background-color: #2D2d2d;
+}


### PR DESCRIPTION
global style for `<option>` for Windows. Doesn't affect macOS. 
Really general solution is to create custom element, otherwise it depends on OS and should be checked in different systems in both dark and light modes